### PR TITLE
task/MA-3999: handle unknown status code cases with exceptions for endpoint class

### DIFF
--- a/consulate/api/base.py
+++ b/consulate/api/base.py
@@ -5,7 +5,6 @@ Base Endpoint class used by all endpoint classes
 import base64
 import json
 
-from requests import HTTPError
 
 try:
     from urllib.parse import urlencode  # Python 3
@@ -54,10 +53,13 @@ class Endpoint(object):
                                         urlencode(query_params))
         return '{0}/{1}'.format(self._base_uri, path)
 
-    # copied from requests.Request raise_for_status method
     @staticmethod
     def _default_raise_error_status(response):
-        """Raises stored :class:`HTTPError`, if one occurred."""
+        """
+        (copied from requests.Request raise_for_status method)
+
+        Raises stored :class:`ServerError`, if one occurred.
+        """
 
         http_error_msg = ''
 
@@ -68,7 +70,7 @@ class Endpoint(object):
             http_error_msg = '%s Server Error' % response.status_code
 
         if http_error_msg:
-            raise HTTPError(http_error_msg)
+            raise exceptions.ServerError(http_error_msg)
 
     def _get(self, params, query_params=None, raise_on_404=False):
         """Perform a GET request

--- a/consulate/api/base.py
+++ b/consulate/api/base.py
@@ -88,7 +88,7 @@ class Endpoint(object):
             if raise_on_404:
                 raise exceptions.NotFound(response.body)
             else:
-                return
+                return []
         else:
             self._default_raise_error_status(response)
 

--- a/consulate/api/base.py
+++ b/consulate/api/base.py
@@ -64,10 +64,10 @@ class Endpoint(object):
         http_error_msg = ''
 
         if 400 <= response.status_code < 500:
-            http_error_msg = '%s Client Error' % response.status_code
+            http_error_msg = '%s Client Error: %s' % (response.status_code, response.body)
 
         elif 500 <= response.status_code < 600:
-            http_error_msg = '%s Server Error' % response.status_code
+            http_error_msg = '%s Server Error: %s' % (response.status_code, response.body)
 
         if http_error_msg:
             raise exceptions.ServerError(http_error_msg)

--- a/consulate/exceptions.py
+++ b/consulate/exceptions.py
@@ -8,6 +8,9 @@ class ConsulateException(Exception):
     """Base Consul exception"""
     pass
 
+class ServerError(ConsulateException):
+    """Raised when unhandled http 4xx or 5xx errors occur"""
+    pass
 
 class ACLDisabled(ConsulateException):
     """Raised when ACL related calls are made while ACLs are disabled"""


### PR DESCRIPTION
https://sightmachine.atlassian.net/browse/MA-3999

I just use how the requests lib handles 4xx, 5xx's and port it over to the consulate repo. Consulate wants to avoid just the 404 ones right now in some cases. 

ran the unit tests on consulate and saw no changes from those results to maintain consistency  (by default right now, they still pass a lot of tests but have 11 errors on python 2.7)